### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Build and Deploy
 
+permissions:
+    contents: read
+
 on:
     push:
         branches:


### PR DESCRIPTION
Potential fix for [https://github.com/DevNinjawork998/personal-website-firebase/security/code-scanning/2](https://github.com/DevNinjawork998/personal-website-firebase/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block either at the top (workflow level, applying to all jobs) or on individual jobs, and set the least privileges required. For purely build-and-test workflows that only check out code and upload artifacts, `contents: read` is typically sufficient. For deployment jobs that use `GITHUB_TOKEN` to interact with the repository or PRs, additional narrow scopes (like `deployments: write` or `pull-requests: write`) might be needed depending on the action’s behavior. Here, the workflow only checks out code, installs dependencies, runs tests, builds, uploads/downloads artifacts, and uses `FirebaseExtended/action-hosting-deploy@v0` with `repoToken`. None of these steps obviously require writing to the repository (no pushes, no PR comments shown), so we can safely set `contents: read` for the entire workflow as a minimal and compatible starting point.

The single best, non-invasive fix is to add a workflow-level permissions block right after the `name` declaration. This will apply to both `build` and `deploy` jobs without needing per-job configuration and without changing their functional behavior: they should all still be able to check out the code and use `GITHUB_TOKEN` for read access. Concretely, in `.github/workflows/deploy.yml`, insert:

```yaml
permissions:
    contents: read
```

after line 1 (`name: Build and Deploy`) and before the `on:` block. No extra imports or methods are required, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
